### PR TITLE
Patch 1

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 var through = require('through2');
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
 var xpath = require('xpath');
 var dom = require('xmldom').DOMParser;
-var PluginError = gutil.PluginError;
 
 // consts
 const PLUGIN_NAME = 'gulp-xpath';

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "Daniel Schmidt <daniel.schmidt@tomtom.com> (https://github.com/donum)"
   ],
   "dependencies": {
-    "gulp-util": "3.0.5",
-    "xmldom": "0.1.19",
+    "plugin-error": "2.0.0",
+    "xmldom": "0.6.0",
     "xpath": "0.0.9",
     "through2": "2.0.0"
   },


### PR DESCRIPTION
Replace gulp-util (deprecated) with plugin-error to eliminate vulnerability from outdated lodash dependency.
Update xmldom to eliminate vulnerability. 